### PR TITLE
Update referenced Mojolicious version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Mojolicious
 =========
 
-Base Mojolicious 4.66 container for octohost.
+Base latest-version Mojolicious container for octohost.
 
 To use an already built container:
 


### PR DESCRIPTION
Correct me if I'm wrong, but I believe that this Docker file will grab whatever is the latest version of Mojolicious and not specifically 4.66?

To incorrectly specify 4.66 here might turn a lot of people off as it it so outdated by now.
